### PR TITLE
fly.io needs health to be open to all

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -11,12 +11,20 @@ function parseAllowedTokens(): Set<string> {
 }
 
 export function apiKeyAuth(req: Request, res: Response, next: NextFunction) {
+  // Allow health checks without a key
+  if (req.method === 'GET' && req.path === '/health') {
+    return next()
+  }
   const tokens = parseAllowedTokens()
   if (tokens.size === 0) {
     // if no tokens configured, deny by default
     return res.status(401).json({ success: false, error: 'API not configured: missing API_TOKENS' })
   }
-  const headerKey = req.header('x-api-key') || req.header('authorization')?.replace(/^Bearer\s+/i, '')
+  const headerKey =
+    req.header('x-api-key') ||
+    req.header('authorization')?.replace(/^Bearer\s+/i, '') ||
+    (req.query.key as string | undefined) ||
+    (req.query.api_key as string | undefined)
   if (!headerKey || !tokens.has(headerKey)) {
     return res.status(401).json({ success: false, error: 'Invalid or missing API key' })
   }


### PR DESCRIPTION
opening `/health` endpoint to no auth