### PR TITLE
Add pub/sub topic messaging service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A personal WhatsApp API server with scheduled messaging, built on Express + Bail
 - 📊 Connection health endpoint
 - 🔐 QR code authentication (+ HTML QR page)
 - 💾 Persistent storage for sessions and schedules
+- 📣 Topic-based pub/sub broadcasts with throttled delivery
 - 🛡️ API key authentication
 
 ## 🚀 Quick Start
@@ -74,6 +75,19 @@ Scheduled Messages
 - DELETE `/scheduled/:id` — Delete
 - POST `/scheduled/:id/toggle` — Activate/Deactivate
 
+Pub/Sub
+- GET `/pubsub/topics` — List topics
+- POST `/pubsub/topics` — Create a topic
+- DELETE `/pubsub/topics/:id` — Delete a topic
+- GET `/pubsub/topics/:id` — Topic details (with subscribers)
+- GET `/pubsub/topics/:id/subscribers` — List subscribers for a topic
+- POST `/pubsub/topics/:id/subscribers` — Subscribe a phone number
+- DELETE `/pubsub/topics/:id/subscribers` — Unsubscribe a phone number
+- GET `/pubsub/subscriptions/:number` — List topics for a phone number
+- POST `/pubsub/publish` — Broadcast a message to a topic
+- GET `/pubsub/settings` — View pub/sub settings
+- PUT `/pubsub/settings` — Update pub/sub settings (e.g., delivery delay)
+
 Utilities
 - GET `/schedule-examples`
 
@@ -101,6 +115,27 @@ curl -X POST http://localhost:3000/scheduled \
     "schedule": "0 10 * * 1",
     "description": "Monday 10am"
   }'
+```
+
+Create a topic and broadcast
+```bash
+# Create a topic
+curl -X POST http://localhost:3000/pubsub/topics \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY>" \
+  -d '{ "name": "Daily Updates" }'
+
+# Subscribe numbers
+curl -X POST http://localhost:3000/pubsub/topics/<TOPIC_ID>/subscribers \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY>" \
+  -d '{ "number": "+1234567890" }'
+
+# Broadcast with the configured delay between each recipient
+curl -X POST http://localhost:3000/pubsub/publish \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY>" \
+  -d '{ "topicId": "<TOPIC_ID>", "message": "Good morning!" }'
 ```
 
 One‑time Sunday 04:27
@@ -137,6 +172,7 @@ More examples in `docs/TEST_CALLS.md`.
 
 - WhatsApp credentials: `sessions/`
 - Scheduled messages: `data/scheduled.json`
+- Pub/Sub topics + subscribers: `data/pubsub.json`
 
 ## 🌐 Deployment
 
@@ -166,6 +202,7 @@ docker run -p 3000:8080 \
 - Keep your API key secret. Rotate if leaked.
 - Persist `sessions/` to avoid scanning again after restarts.
 - Monitor `/health` and logs for connection state.
+- Baileys does not expose throttling controls, so the pub/sub sender enforces your configured delay between each recipient to avoid spamming WhatsApp.
 
 ## 📚 References
 

--- a/src/services/pubsub.ts
+++ b/src/services/pubsub.ts
@@ -1,0 +1,254 @@
+import fs from 'fs'
+import path from 'path'
+import { v4 as uuidv4 } from 'uuid'
+import pino from 'pino'
+import { z } from 'zod'
+import type { WhatsAppClient } from './whatsapp.js'
+
+const subscriberSchema = z.object({
+  number: z.string(),
+  subscribedAt: z.string()
+})
+
+const topicSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional().default(''),
+  subscribers: z.array(subscriberSchema).default([]),
+  created: z.string(),
+  updated: z.string()
+})
+
+const settingsSchema = z.object({
+  messageDelaySeconds: z.number().min(0).default(1)
+})
+
+const pubSubDataSchema = z.object({
+  topics: z.array(topicSchema).default([]),
+  settings: settingsSchema.default({ messageDelaySeconds: 1 })
+})
+
+export type TopicSubscriber = z.infer<typeof subscriberSchema>
+export type PubSubTopic = z.infer<typeof topicSchema>
+export type PubSubSettings = z.infer<typeof settingsSchema>
+
+export type PublishResult = {
+  number: string
+  success: boolean
+  error?: string
+}
+
+export type PublishSummary = {
+  topic: PubSubTopic
+  attempted: number
+  delivered: number
+  results: PublishResult[]
+}
+
+export class PubSubService {
+  private readonly dataFile: string
+  private readonly logger = pino({ level: process.env.LOG_LEVEL || 'info' })
+  private readonly whatsappClient: WhatsAppClient
+  private data: z.infer<typeof pubSubDataSchema> = {
+    topics: [],
+    settings: { messageDelaySeconds: 1 }
+  }
+
+  constructor(dataDir = path.resolve(process.cwd(), 'data'), whatsappClient: WhatsAppClient) {
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true })
+    }
+    this.dataFile = path.join(dataDir, 'pubsub.json')
+    this.whatsappClient = whatsappClient
+    this.load()
+  }
+
+  private load() {
+    try {
+      if (fs.existsSync(this.dataFile)) {
+        const raw = fs.readFileSync(this.dataFile, 'utf8')
+        const parsed = JSON.parse(raw)
+        this.data = pubSubDataSchema.parse(parsed)
+      }
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to load pub/sub data')
+      this.data = { topics: [], settings: { messageDelaySeconds: 1 } }
+    }
+  }
+
+  private save() {
+    try {
+      fs.writeFileSync(this.dataFile, JSON.stringify(this.data, null, 2))
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to save pub/sub data')
+    }
+  }
+
+  public listTopics(): PubSubTopic[] {
+    return this.data.topics
+  }
+
+  public getTopic(id: string): PubSubTopic | undefined {
+    return this.data.topics.find((topic) => topic.id === id)
+  }
+
+  public getTopicByName(name: string): PubSubTopic | undefined {
+    const normalized = name.trim().toLowerCase()
+    return this.data.topics.find((topic) => topic.name.trim().toLowerCase() === normalized)
+  }
+
+  public createTopic(input: { name: string; description?: string | undefined }): PubSubTopic {
+    const name = input.name.trim()
+    if (!name) {
+      throw new Error('Topic name is required')
+    }
+    if (this.getTopicByName(name)) {
+      throw new Error('Topic with this name already exists')
+    }
+    const now = new Date().toISOString()
+    const topic: PubSubTopic = {
+      id: uuidv4(),
+      name,
+      description: input.description?.trim() ?? '',
+      subscribers: [],
+      created: now,
+      updated: now
+    }
+    this.data.topics.push(topic)
+    this.save()
+    return topic
+  }
+
+  public deleteTopic(id: string): boolean {
+    const idx = this.data.topics.findIndex((topic) => topic.id === id)
+    if (idx === -1) return false
+    this.data.topics.splice(idx, 1)
+    this.save()
+    return true
+  }
+
+  public listSubscribers(topicId: string): TopicSubscriber[] | null {
+    const topic = this.getTopic(topicId)
+    if (!topic) return null
+    return topic.subscribers
+  }
+
+  public subscribe(topicId: string, number: string): { topic: PubSubTopic; created: boolean } {
+    const topic = this.getTopic(topicId)
+    if (!topic) {
+      throw new Error('Topic not found')
+    }
+    const normalizedNumber = this.normalizeNumber(number)
+    if (!normalizedNumber) {
+      throw new Error('Phone number must contain digits')
+    }
+    const existing = topic.subscribers.find((sub) => sub.number === normalizedNumber)
+    if (existing) {
+      return { topic, created: false }
+    }
+    const now = new Date().toISOString()
+    topic.subscribers.push({ number: normalizedNumber, subscribedAt: now })
+    topic.updated = now
+    this.save()
+    return { topic, created: true }
+  }
+
+  public unsubscribe(topicId: string, number: string): { topic: PubSubTopic; removed: boolean } {
+    const topic = this.getTopic(topicId)
+    if (!topic) {
+      throw new Error('Topic not found')
+    }
+    const normalizedNumber = this.normalizeNumber(number)
+    if (!normalizedNumber) {
+      throw new Error('Phone number must contain digits')
+    }
+    const prevLength = topic.subscribers.length
+    topic.subscribers = topic.subscribers.filter((sub) => sub.number !== normalizedNumber)
+    const removed = topic.subscribers.length !== prevLength
+    if (removed) {
+      topic.updated = new Date().toISOString()
+      this.save()
+    }
+    return { topic, removed }
+  }
+
+  public getSubscriptionStatus(number: string): { number: string; normalized: string; topics: Array<Pick<PubSubTopic, 'id' | 'name'>> } {
+    const normalized = this.normalizeNumber(number)
+    if (!normalized) {
+      throw new Error('Phone number must contain digits')
+    }
+    const topics = this.data.topics
+      .filter((topic) => topic.subscribers.some((sub) => sub.number === normalized))
+      .map((topic) => ({ id: topic.id, name: topic.name }))
+    return { number, normalized, topics }
+  }
+
+  public getSettings(): PubSubSettings {
+    return this.data.settings
+  }
+
+  public updateSettings(settings: { messageDelaySeconds?: number | undefined }): PubSubSettings {
+    if (settings.messageDelaySeconds !== undefined) {
+      if (settings.messageDelaySeconds < 0) {
+        throw new Error('messageDelaySeconds must be zero or greater')
+      }
+      this.data.settings.messageDelaySeconds = settings.messageDelaySeconds
+    }
+    this.save()
+    return this.data.settings
+  }
+
+  public async publish(topicId: string, message: string): Promise<PublishSummary> {
+    const topic = this.getTopic(topicId)
+    if (!topic) {
+      throw new Error('Topic not found')
+    }
+    if (!message.trim()) {
+      throw new Error('Message is required')
+    }
+    if (this.whatsappClient.getConnectionStatus() !== 'connected') {
+      throw new Error('WhatsApp not connected')
+    }
+    const socket = this.whatsappClient.getSocket()
+    if (!socket) {
+      throw new Error('WhatsApp socket unavailable')
+    }
+    const delayMs = Math.max(0, Math.round(this.data.settings.messageDelaySeconds * 1000))
+    const results: PublishResult[] = []
+    let delivered = 0
+    for (const [index, sub] of topic.subscribers.entries()) {
+      const jid = this.formatJid(sub.number)
+      try {
+        await socket.sendMessage(jid, { text: message })
+        delivered += 1
+        results.push({ number: sub.number, success: true })
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Failed to send message'
+        results.push({ number: sub.number, success: false, error: errorMessage })
+        this.logger.error({ err, topicId, number: sub.number }, 'Failed to publish message to subscriber')
+      }
+      if (delayMs > 0 && index < topic.subscribers.length - 1) {
+        await this.delay(delayMs)
+      }
+    }
+    return {
+      topic,
+      attempted: topic.subscribers.length,
+      delivered,
+      results
+    }
+  }
+
+  private normalizeNumber(number: string): string {
+    return number.replace(/[^0-9]/g, '')
+  }
+
+  private formatJid(number: string): string {
+    const normalized = this.normalizeNumber(number)
+    return `${normalized}@s.whatsapp.net`
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms))
+  }
+}


### PR DESCRIPTION
## Summary
- add a persistent PubSubService to manage topics, subscribers and throttled broadcasts
- expose REST endpoints for topic CRUD, subscription management, publishing, and settings
- document the new pub/sub capabilities and storage details in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2aa4bdec832486600d900071a253