### PR TITLE
Add group chat messaging to Baylis api

### DIFF
--- a/api-spec.openai
+++ b/api-spec.openai
@@ -91,10 +91,52 @@ paths:
                           - "Already authenticated"
                           - "QR code not available yet, please wait..."
 
+  /groups:
+    get:
+      summary: Get WhatsApp groups
+      description: Returns a list of all WhatsApp groups the user is part of
+      operationId: getGroups
+      tags:
+        - Groups
+      responses:
+        '200':
+          description: List of groups
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  groups:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        jid:
+                          type: string
+                          description: Group JID (unique identifier)
+                          example: "120363147258369076@g.us"
+                        name:
+                          type: string
+                          description: Group name
+                          example: "Family Group"
+                        participants:
+                          type: integer
+                          description: Number of participants in the group
+                          example: 10
+        '503':
+          description: WhatsApp not connected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /send:
     post:
       summary: Send immediate WhatsApp message
-      description: Sends a WhatsApp message immediately to the specified number
+      description: Sends a WhatsApp message immediately to the specified number or group JID
       operationId: sendMessage
       tags:
         - Messaging
@@ -105,13 +147,16 @@ paths:
             schema:
               type: object
               required:
-                - number
                 - message
               properties:
                 number:
                   type: string
-                  description: Phone number without country code prefix
+                  description: Phone number without country code prefix (either number or jid must be provided)
                   example: "1234567890"
+                jid:
+                  type: string
+                  description: WhatsApp JID for groups or direct formatted numbers (either number or jid must be provided)
+                  example: "120363147258369076@g.us"
                 message:
                   type: string
                   description: Message content to send
@@ -201,14 +246,17 @@ paths:
             schema:
               type: object
               required:
-                - number
                 - message
                 - schedule
               properties:
                 number:
                   type: string
-                  description: Phone number without country code prefix
+                  description: Phone number without country code prefix (either number or jid must be provided)
                   example: "1234567890"
+                jid:
+                  type: string
+                  description: WhatsApp JID for groups or direct formatted numbers (either number or jid must be provided)
+                  example: "120363147258369076@g.us"
                 message:
                   type: string
                   description: Message content to send
@@ -271,7 +319,10 @@ paths:
               properties:
                 number:
                   type: string
-                  description: Phone number
+                  description: Phone number (optional if jid provided)
+                jid:
+                  type: string
+                  description: WhatsApp JID for groups or direct formatted numbers
                 message:
                   type: string
                   description: Message content
@@ -399,14 +450,17 @@ paths:
             schema:
               type: object
               required:
-                - number
                 - message
                 - scheduleDate
               properties:
                 number:
                   type: string
-                  description: Phone number without country code prefix
+                  description: Phone number without country code prefix (either number or jid must be provided)
                   example: "1234567890"
+                jid:
+                  type: string
+                  description: WhatsApp JID for groups or direct formatted numbers (either number or jid must be provided)
+                  example: "120363147258369076@g.us"
                 message:
                   type: string
                   description: Message content to send
@@ -604,8 +658,12 @@ components:
           example: "123e4567-e89b-12d3-a456-426614174000"
         number:
           type: string
-          description: Phone number
+          description: Phone number (optional if jid is provided)
           example: "1234567890"
+        jid:
+          type: string
+          description: WhatsApp JID for groups or direct formatted numbers (optional if number is provided)
+          example: "120363147258369076@g.us"
         message:
           type: string
           description: Message content
@@ -662,6 +720,8 @@ tags:
     description: System status and health endpoints
   - name: Authentication
     description: WhatsApp authentication and QR code endpoints
+  - name: Groups
+    description: WhatsApp group management
   - name: Messaging
     description: Immediate message sending
   - name: Scheduled Messages

--- a/docs/GROUP_MESSAGING.md
+++ b/docs/GROUP_MESSAGING.md
@@ -1,0 +1,177 @@
+# WhatsApp Group Messaging Documentation
+
+This document explains how to send direct and scheduled messages to WhatsApp groups using the updated API.
+
+## Overview
+
+The WhatsApp API has been enhanced to support sending messages to groups in addition to individual phone numbers. This is achieved by using WhatsApp JIDs (Jabber IDs) which are unique identifiers for groups.
+
+## Key Changes
+
+### 1. New `/groups` Endpoint
+
+Fetch all WhatsApp groups you're part of:
+
+```http
+GET /groups
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "groups": [
+    {
+      "jid": "120363147258369076@g.us",
+      "name": "Family Group",
+      "participants": 10
+    },
+    {
+      "jid": "120363147258369077@g.us", 
+      "name": "Work Team",
+      "participants": 25
+    }
+  ]
+}
+```
+
+### 2. Updated `/send` Endpoint
+
+The send endpoint now accepts either a `number` OR a `jid`:
+
+**Send to a phone number:**
+```json
+POST /send
+{
+  "number": "1234567890",
+  "message": "Hello!"
+}
+```
+
+**Send to a group:**
+```json
+POST /send
+{
+  "jid": "120363147258369076@g.us",
+  "message": "Hello group!"
+}
+```
+
+### 3. Updated Scheduled Messages
+
+Both cron-based and date-based scheduled messages now support groups:
+
+**Schedule recurring message to group:**
+```json
+POST /scheduled
+{
+  "jid": "120363147258369076@g.us",
+  "message": "Weekly team reminder",
+  "schedule": "0 9 * * 1",
+  "description": "Monday morning team sync reminder"
+}
+```
+
+**Schedule one-time message to group:**
+```json
+POST /scheduleDate
+{
+  "jid": "120363147258369076@g.us",
+  "message": "Happy New Year team! 🎉",
+  "scheduleDate": "2025-01-01T00:00:00Z",
+  "description": "New Year greeting"
+}
+```
+
+## Implementation Approach
+
+### Architecture Changes
+
+1. **WhatsApp Service (`/src/services/whatsapp.ts`)**
+   - Added `getGroupChats()` method that uses Baileys' `groupFetchAllParticipating()` to fetch all groups
+   - Returns simplified group data with JID, name, and participant count
+
+2. **Server Routes (`/src/server.ts`)**
+   - Added `/groups` GET endpoint
+   - Modified all message-sending endpoints to accept optional `jid` parameter
+   - Updated validation schemas to require either `number` OR `jid`
+
+3. **Scheduler Service (`/src/services/scheduler.ts`)**
+   - Updated `ScheduledMessage` schema to include optional `jid` field
+   - Modified `formatJid()` method to handle both phone numbers and group JIDs
+   - Updated `create()` and `createDateSchedule()` methods to accept JIDs
+
+### JID Format
+
+- **Individual numbers:** `{number}@s.whatsapp.net` (e.g., `1234567890@s.whatsapp.net`)
+- **Groups:** `{groupId}@g.us` (e.g., `120363147258369076@g.us`)
+
+The system automatically formats phone numbers into JIDs but uses provided JIDs directly.
+
+## Usage Examples
+
+### Example 1: Get all groups and send a message
+
+```bash
+# 1. Get all groups
+curl -X GET http://localhost:3000/groups \
+  -H "x-api-key: YOUR_API_KEY"
+
+# 2. Send message to a specific group
+curl -X POST http://localhost:3000/send \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jid": "120363147258369076@g.us",
+    "message": "Hello everyone!"
+  }'
+```
+
+### Example 2: Schedule daily standup reminder
+
+```bash
+curl -X POST http://localhost:3000/scheduled \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jid": "120363147258369076@g.us",
+    "message": "Daily standup in 15 minutes! 📋",
+    "schedule": "45 9 * * 1-5",
+    "description": "Daily standup reminder (weekdays at 9:45 AM)"
+  }'
+```
+
+### Example 3: Schedule a birthday message to a group
+
+```bash
+curl -X POST http://localhost:3000/scheduleDate \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jid": "120363147258369076@g.us",
+    "message": "Happy Birthday Sarah! 🎂🎉",
+    "scheduleDate": "2025-03-15T09:00:00Z",
+    "description": "Sarah birthday message to team group"
+  }'
+```
+
+## Backward Compatibility
+
+All existing functionality remains intact:
+- Endpoints that previously accepted only `number` now accept either `number` OR `jid`
+- Existing scheduled messages with phone numbers continue to work
+- The API maintains full backward compatibility
+
+## Error Handling
+
+- If neither `number` nor `jid` is provided: Returns 400 error
+- If WhatsApp is not connected: Returns 503 error
+- If group JID is invalid: Message sending will fail with appropriate error
+
+## Benefits
+
+1. **Unified Interface:** Same endpoints work for both individual and group messaging
+2. **Flexibility:** Choose between phone numbers or JIDs based on your needs
+3. **Group Management:** Easy discovery of available groups via `/groups` endpoint
+4. **Scheduling:** Full scheduling support for group messages (recurring and one-time)
+5. **Backward Compatible:** No breaking changes to existing integrations

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -8,7 +8,8 @@ import type { ConnectionStatus, WhatsAppClient } from './whatsapp.js'
 
 export const scheduledMessageSchema = z.object({
   id: z.string(),
-  number: z.string(),
+  number: z.string().optional(),
+  jid: z.string().optional(),
   message: z.string(),
   schedule: z.string(),
   description: z.string().optional().default(''),
@@ -87,7 +88,7 @@ export class SchedulerService {
         try {
           const sock = this.whatsappClient.getSocket()
           if (!sock) return
-          const jid = this.formatJid(msg.number)
+          const jid = this.formatJid(msg)
           await sock.sendMessage(jid, { text: msg.message })
           this.logger.info({ id: msg.id }, 'Scheduled message sent')
           if (msg.oneTime) {
@@ -141,7 +142,7 @@ export class SchedulerService {
     try {
       const sock = this.whatsappClient.getSocket()
       if (!sock) return
-      const jid = this.formatJid(msg.number)
+      const jid = this.formatJid(msg)
       await sock.sendMessage(jid, { text: msg.message })
       this.logger.info({ id: msg.id }, 'Scheduled message sent')
       this.markAsExecuted(msg.id)
@@ -162,9 +163,17 @@ export class SchedulerService {
     }
   }
 
-  private formatJid(number: string) {
-    const trimmed = number.replace(/[^0-9]/g, '')
-    return `${trimmed}@s.whatsapp.net`
+  private formatJid(msg: ScheduledMessage): string {
+    if (msg.jid) {
+      // Use the provided JID directly (for groups or already formatted numbers)
+      return msg.jid
+    } else if (msg.number) {
+      // Format the phone number as a JID
+      const trimmed = msg.number.replace(/[^0-9]/g, '')
+      return `${trimmed}@s.whatsapp.net`
+    } else {
+      throw new Error('No recipient specified')
+    }
   }
 
   private restoreJobs() {
@@ -173,14 +182,18 @@ export class SchedulerService {
     }
   }
 
-  public create(input: { number: string; message: string; schedule: string; description?: string; oneTime?: boolean }): ScheduledMessage {
+  public create(input: { number?: string; jid?: string; message: string; schedule: string; description?: string; oneTime?: boolean }): ScheduledMessage {
     if (!cron.validate(input.schedule)) {
       throw new Error('Invalid cron expression')
+    }
+    if (!input.number && !input.jid) {
+      throw new Error('Either number or jid must be provided')
     }
     const now = new Date().toISOString()
     const msg: ScheduledMessage = {
       id: uuidv4(),
       number: input.number,
+      jid: input.jid,
       message: input.message,
       schedule: input.schedule,
       description: input.description || '',
@@ -196,11 +209,15 @@ export class SchedulerService {
     return msg
   }
   
-  public createDateSchedule(input: { number: string; message: string; scheduleDate: string; description?: string }): ScheduledMessage {
+  public createDateSchedule(input: { number?: string; jid?: string; message: string; scheduleDate: string; description?: string }): ScheduledMessage {
     // Validate the date
     const scheduledTime = new Date(input.scheduleDate)
     if (isNaN(scheduledTime.getTime())) {
       throw new Error('Invalid date format')
+    }
+    
+    if (!input.number && !input.jid) {
+      throw new Error('Either number or jid must be provided')
     }
     
     // Check if date is in the past (allow 1 minute grace period)
@@ -213,6 +230,7 @@ export class SchedulerService {
     const msg: ScheduledMessage = {
       id: uuidv4(),
       number: input.number,
+      jid: input.jid,
       message: input.message,
       schedule: '', // Empty for date-based schedules
       scheduleDate: input.scheduleDate,
@@ -248,6 +266,7 @@ export class SchedulerService {
     const next: ScheduledMessage = {
       id: prev.id,
       number: updates.number ?? prev.number,
+      jid: updates.jid ?? prev.jid,
       message: updates.message ?? prev.message,
       schedule: updates.schedule ?? prev.schedule,
       scheduleDate: updates.scheduleDate ?? prev.scheduleDate,

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -265,8 +265,8 @@ export class SchedulerService {
     
     const next: ScheduledMessage = {
       id: prev.id,
-      number: updates.number ?? prev.number,
-      jid: updates.jid ?? prev.jid,
+      number: updates.number !== undefined ? updates.number : prev.number,
+      jid: updates.jid !== undefined ? updates.jid : prev.jid,
       message: updates.message ?? prev.message,
       schedule: updates.schedule ?? prev.schedule,
       scheduleDate: updates.scheduleDate ?? prev.scheduleDate,
@@ -276,6 +276,11 @@ export class SchedulerService {
       executed: updates.executed ?? prev.executed,
       created: prev.created,
       updated: new Date().toISOString()
+    }
+    
+    // Validate that at least one recipient (number or jid) remains after update
+    if (!next.number && !next.jid) {
+      throw new Error('Either number or jid must be provided')
     }
     this.messages[idx] = next
     this.save()

--- a/src/services/whatsapp.ts
+++ b/src/services/whatsapp.ts
@@ -90,6 +90,29 @@ export class WhatsAppClient {
     this.qrState = {}
     await this.start()
   }
+
+  public async getGroupChats(): Promise<Array<{ jid: string; name: string; participants: number }>> {
+    if (this.status !== 'connected' || !this.socket) {
+      throw new Error('WhatsApp not connected')
+    }
+    
+    try {
+      // Get all chats
+      const chats = await this.socket.groupFetchAllParticipating()
+      
+      // Transform the group data into a simpler format
+      const groups = Object.entries(chats).map(([jid, group]) => ({
+        jid,
+        name: group.subject || 'Unnamed Group',
+        participants: group.participants ? group.participants.length : 0
+      }))
+      
+      return groups
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to fetch group chats')
+      throw new Error('Failed to fetch group chats')
+    }
+  }
 }
 
 


### PR DESCRIPTION
Add support for sending direct and scheduled messages to WhatsApp groups and a new endpoint to retrieve group chats.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebdc2c74-0f1e-403b-aeae-8582c8bbbf2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebdc2c74-0f1e-403b-aeae-8582c8bbbf2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

