### PR TITLE
Record sent messages to redis streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,13 @@ curl -X PUT http://localhost:3000/settings \
 curl -X PUT http://localhost:3000/settings \
   -H "Content-Type: application/json" \
   -H "x-api-key: <API_KEY>" \
-  -d '{
-    "history_backend": "base44",
-    "base44": {
-      "url": "https://api.base44.com/records",
-      "apiKey": "your-base44-api-key"
-    }
-  }'
+  -d '{"history_backend": "base44"}'
 ```
+
+**Environment Variables for Base44**
+- `BASE44_URL` - Base44 API endpoint URL  
+- `BASE44_KEY` - Base44 API authentication key
+- `FLY_RELEASE_VERSION` - Used for external system identification (auto-set by Fly.io)
 
 **Redis Backend Usage** (when `history_backend: "redis"`)
 ```bash

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Configure comma‑separated keys via `API_TOKENS`.
 - `POST /pubsub/publish` — Broadcast messages to topic subscribers
 - `GET /pubsub/settings` — View/update broadcast settings
 
+### Settings
+- `GET /settings` — Get application settings including message history backend
+- `PUT /settings` — Update application settings
+- `GET /settings/recording-status` — Check message recording backend status
+
 ### Utilities
 - `GET /schedule-examples` — Cron expression examples and help
 
@@ -95,14 +100,42 @@ Configure comma‑separated keys via `API_TOKENS`.
 
 ### Sent History
 
-When Redis is configured, all successfully sent messages are automatically recorded to `sent_history` Redis stream with a hash index for fast lookups.
+All successfully sent messages are automatically recorded using the configured backend. The system supports multiple backends for message history storage:
 
+**Backend Configuration**
+```bash
+# Configure Redis backend (default)
+curl -X PUT http://localhost:3000/settings \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY>" \
+  -d '{"history_backend": "redis"}'
+
+# Configure Base44 backend
+curl -X PUT http://localhost:3000/settings \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY>" \
+  -d '{
+    "history_backend": "base44",
+    "base44": {
+      "url": "https://api.base44.com/records",
+      "apiKey": "your-base44-api-key"
+    }
+  }'
+```
+
+**Redis Backend Usage** (when `history_backend: "redis"`)
 ```bash
 # Show last 5 sent records
 XRANGE sent_history - + COUNT 5
 
 # Lookup by id
 HGETALL sent:index:<id>
+```
+
+**Status Check**
+```bash
+# Check recording backend status
+curl -H "x-api-key: <API_KEY>" http://localhost:3000/settings/recording-status
 ```
 
 ### Redis Health

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Configure comma‑separated keys via `API_TOKENS`.
 
 📖 **Complete API Documentation**: See [API Reference](docs/API_REFERENCE.md) for detailed schemas and examples.
 
+### Sent History
+
+When Redis is configured, all successfully sent messages are automatically recorded to `sent_history` Redis stream with a hash index for fast lookups.
+
+```bash
+# Show last 5 sent records
+XRANGE sent_history - + COUNT 5
+
+# Lookup by id
+HGETALL sent:index:<id>
+```
+
 ### Redis Health
 
 Quick readiness probe for Redis:

--- a/src/queue/sentRecorder.ts
+++ b/src/queue/sentRecorder.ts
@@ -1,0 +1,24 @@
+import { redis, STREAM_SENT, ROUTING_MAXLEN } from '../infra/redis.js';
+import { SentRecord } from '../dto/messages.js';
+
+export async function recordSent(rec: SentRecord): Promise<string> {
+  if (!redis) {
+    throw new Error('Redis not configured');
+  }
+  
+  const json = JSON.stringify(rec);
+  const id = await redis.xadd(
+    STREAM_SENT, 'MAXLEN', '~', ROUTING_MAXLEN.toString(), '*', 'v', json
+  );
+  const idxKey = `sent:index:${rec.id}`;
+  await redis.hset(idxKey, {
+    ts: String(rec.ts), 
+    to: rec.to, 
+    chatId: rec.chatId || '',
+    via: rec.via, 
+    corr: rec.correlationId || '',
+    waId: rec.waMessageId || '', 
+    ddk: rec.dedupeKey || ''
+  });
+  return id;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -483,11 +483,7 @@ app.get('/settings', (req, res) => {
 })
 
 const updateSettingsSchema = z.object({
-  history_backend: z.enum(['redis', 'base44']).optional(),
-  base44: z.object({
-    url: z.string().url(),
-    apiKey: z.string().min(1)
-  }).optional()
+  history_backend: z.enum(['redis', 'base44']).optional()
 })
 
 app.put('/settings', (req, res) => {
@@ -500,9 +496,6 @@ app.put('/settings', (req, res) => {
     const updates: any = {}
     if (parse.data.history_backend !== undefined) {
       updates.history_backend = parse.data.history_backend
-    }
-    if (parse.data.base44 !== undefined) {
-      updates.base44 = parse.data.base44
     }
     const updatedSettings = settingsService.updateSettings(updates)
     res.json({ success: true, message: 'Settings updated', settings: updatedSettings })

--- a/src/services/messageRecordingService.ts
+++ b/src/services/messageRecordingService.ts
@@ -1,0 +1,90 @@
+import pino from 'pino';
+import { SentRecord } from '../dto/messages.js';
+import { SentMessageRecorder, SentMessageRecorderFactory } from './sentMessageRecorder.js';
+import { SettingsService } from './settingsService.js';
+
+export class MessageRecordingService {
+  private readonly logger = pino({ level: process.env.LOG_LEVEL || 'info' });
+  private recorder: SentMessageRecorder | null = null;
+  private lastHealthCheck = 0;
+  private readonly healthCheckInterval = 30000; // 30 seconds
+
+  constructor(private readonly settingsService: SettingsService) {}
+
+  private async ensureRecorder(): Promise<SentMessageRecorder | null> {
+    const now = Date.now();
+    
+    // Re-initialize recorder if settings might have changed or it's been a while
+    if (!this.recorder || (now - this.lastHealthCheck) > this.healthCheckInterval) {
+      try {
+        const settings = this.settingsService.getRecorderSettings();
+        this.recorder = await SentMessageRecorderFactory.create(settings);
+        this.lastHealthCheck = now;
+      } catch (err) {
+        this.logger.error({ err }, 'Failed to initialize message recorder');
+        this.recorder = null;
+      }
+    }
+    
+    return this.recorder;
+  }
+
+  public async recordSent(record: SentRecord): Promise<string | null> {
+    try {
+      const recorder = await this.ensureRecorder();
+      
+      if (!recorder) {
+        this.logger.warn('No message recorder available');
+        return null;
+      }
+
+      // Check if backend is healthy before attempting to record
+      const isHealthy = await recorder.isHealthy();
+      if (!isHealthy) {
+        this.logger.warn({ backend: recorder.getBackendType() }, 'Message recorder backend is unhealthy');
+        return null;
+      }
+
+      const recordId = await recorder.recordSent(record);
+      
+      this.logger.info({ 
+        evt: 'sent_recorded', 
+        id: record.id, 
+        to: record.to, 
+        via: record.via,
+        backend: recorder.getBackendType(),
+        recordId 
+      });
+      
+      return recordId;
+    } catch (err) {
+      this.logger.error({ err, record: record.id }, 'Failed to record sent message');
+      return null;
+    }
+  }
+
+  public async getBackendStatus(): Promise<{
+    backend: string;
+    healthy: boolean;
+    available: boolean;
+  } | null> {
+    try {
+      const recorder = await this.ensureRecorder();
+      
+      if (!recorder) {
+        return { backend: 'none', healthy: false, available: false };
+      }
+
+      const healthy = await recorder.isHealthy();
+      
+      return {
+        backend: recorder.getBackendType(),
+        healthy,
+        available: true
+      };
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to get backend status');
+      return null;
+    }
+  }
+}

--- a/src/services/pubsub.ts
+++ b/src/services/pubsub.ts
@@ -4,8 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import pino from 'pino'
 import { z } from 'zod'
 import type { WhatsAppClient } from './whatsapp.js'
-import { recordSent } from '../queue/sentRecorder.js'
-import { isRedisConfigured, redis } from '../infra/redis.js'
+import type { MessageRecordingService } from './messageRecordingService.js'
 
 const subscriberSchema = z.object({
   number: z.string(),
@@ -56,7 +55,11 @@ export class PubSubService {
     settings: { messageDelaySeconds: 1 }
   }
 
-  constructor(dataDir = path.resolve(process.cwd(), 'data'), whatsappClient: WhatsAppClient) {
+  constructor(
+    dataDir = path.resolve(process.cwd(), 'data'), 
+    whatsappClient: WhatsAppClient,
+    private readonly messageRecording?: MessageRecordingService
+  ) {
     if (!fs.existsSync(dataDir)) {
       fs.mkdirSync(dataDir, { recursive: true })
     }
@@ -225,8 +228,8 @@ export class PubSubService {
         delivered += 1
         results.push({ number: sub.number, success: true })
         
-        // Record sent message if Redis is configured
-        if (isRedisConfigured && redis) {
+        // Record sent message using the configured backend
+        if (this.messageRecording) {
           try {
             const rec = {
               id: `${Date.now()}-${Math.random().toString(36).slice(2,8)}`,
@@ -238,8 +241,7 @@ export class PubSubService {
               correlationId: `topic:${topicId}`,
               ...(result?.key?.id && { waMessageId: result.key.id })
             }
-            await recordSent(rec)
-            this.logger.info({ evt: 'sent_recorded', id: rec.id, to: rec.to, via: rec.via })
+            await this.messageRecording.recordSent(rec)
           } catch (err) {
             this.logger.error({ err }, 'Failed to record sent message')
           }

--- a/src/services/recorders/base44Recorder.ts
+++ b/src/services/recorders/base44Recorder.ts
@@ -1,0 +1,64 @@
+import { SentMessageRecorder } from '../sentMessageRecorder.js';
+import { SentRecord } from '../../dto/messages.js';
+
+export class Base44Recorder implements SentMessageRecorder {
+  constructor(
+    private readonly apiUrl: string,
+    private readonly apiKey: string
+  ) {}
+
+  async recordSent(record: SentRecord): Promise<string> {
+    // TODO: Implement Base44 API call
+    // This is a stub implementation
+    
+    try {
+      // Placeholder for actual API call to Base44
+      const response = await this.makeBase44ApiCall(record);
+      return response.id || `base44-${Date.now()}`;
+    } catch (error) {
+      throw new Error(`Base44 recording failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    if (!this.apiUrl || !this.apiKey) {
+      return false;
+    }
+    
+    try {
+      // TODO: Implement health check endpoint call
+      // For now, just check if we have the required config
+      return this.apiUrl.startsWith('http') && this.apiKey.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  getBackendType(): string {
+    return 'base44';
+  }
+
+  private async makeBase44ApiCall(record: SentRecord): Promise<{ id: string }> {
+    // TODO: Implement actual Base44 API integration
+    // This is a stub that will be implemented later
+    
+    const payload = {
+      id: record.id,
+      timestamp: record.ts,
+      recipient: record.to,
+      chatId: record.chatId,
+      messageType: record.via,
+      bodyPreview: record.bodyPreview,
+      correlationId: record.correlationId,
+      whatsappMessageId: record.waMessageId,
+      dedupeKey: record.dedupeKey
+    };
+
+    // Stub response - replace with actual fetch call later
+    console.log(`[Base44 Stub] Would send to ${this.apiUrl} with payload:`, payload);
+    
+    return {
+      id: `base44-${record.id}-${Date.now()}`
+    };
+  }
+}

--- a/src/services/recorders/base44Recorder.ts
+++ b/src/services/recorders/base44Recorder.ts
@@ -2,19 +2,25 @@ import { SentMessageRecorder } from '../sentMessageRecorder.js';
 import { SentRecord } from '../../dto/messages.js';
 
 export class Base44Recorder implements SentMessageRecorder {
-  constructor(
-    private readonly apiUrl: string,
-    private readonly apiKey: string
-  ) {}
+  private readonly apiUrl: string;
+  private readonly apiKey: string;
+  private readonly externalSystem: string;
+
+  constructor() {
+    this.apiUrl = process.env.BASE44_URL || '';
+    this.apiKey = process.env.BASE44_KEY || '';
+    const flyReleaseVersion = process.env.FLY_RELEASE_VERSION || '';
+    this.externalSystem = `flyio-whatsapp-personal-api-v${flyReleaseVersion}`;
+  }
 
   async recordSent(record: SentRecord): Promise<string> {
-    // TODO: Implement Base44 API call
-    // This is a stub implementation
-    
+    if (!this.apiUrl || !this.apiKey) {
+      throw new Error('Base44 API URL and key must be configured via BASE44_URL and BASE44_KEY environment variables');
+    }
+
     try {
-      // Placeholder for actual API call to Base44
       const response = await this.makeBase44ApiCall(record);
-      return response.id || `base44-${Date.now()}`;
+      return response.id || `base44-${record.id}`;
     } catch (error) {
       throw new Error(`Base44 recording failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -26,8 +32,7 @@ export class Base44Recorder implements SentMessageRecorder {
     }
     
     try {
-      // TODO: Implement health check endpoint call
-      // For now, just check if we have the required config
+      // Basic health check - verify URL format and API key presence
       return this.apiUrl.startsWith('http') && this.apiKey.length > 0;
     } catch {
       return false;
@@ -39,26 +44,46 @@ export class Base44Recorder implements SentMessageRecorder {
   }
 
   private async makeBase44ApiCall(record: SentRecord): Promise<{ id: string }> {
-    // TODO: Implement actual Base44 API integration
-    // This is a stub that will be implemented later
-    
-    const payload = {
-      id: record.id,
-      timestamp: record.ts,
-      recipient: record.to,
-      chatId: record.chatId,
-      messageType: record.via,
-      bodyPreview: record.bodyPreview,
-      correlationId: record.correlationId,
-      whatsappMessageId: record.waMessageId,
-      dedupeKey: record.dedupeKey
+    // Build payload according to Base44 API specification
+    const payload: any = {
+      message_type: record.correlationId?.startsWith('topic:') ? 'instant' : 
+                   record.correlationId ? 'scheduled' : 'instant',
+      number: record.to,
+      message: record.bodyPreview || '',
+      status: 'sent',
+      sent_at: new Date(record.ts).toISOString(),
+      external_system: this.externalSystem,
+      response_data: {
+        whatsapp_message_id: record.waMessageId,
+        chat_id: record.chatId,
+        message_via: record.via,
+        dedupe_key: record.dedupeKey,
+        internal_record_id: record.id
+      }
     };
 
-    // Stub response - replace with actual fetch call later
-    console.log(`[Base44 Stub] Would send to ${this.apiUrl} with payload:`, payload);
-    
+    // Add scheduled-specific fields if applicable
+    if (record.correlationId && !record.correlationId.startsWith('topic:')) {
+      payload.scheduled_message_id = record.correlationId;
+    }
+
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'Unknown error');
+      throw new Error(`Base44 API error ${response.status}: ${errorText}`);
+    }
+
+    const result = await response.json();
     return {
-      id: `base44-${record.id}-${Date.now()}`
+      id: result.id || result.record_id || `base44-${record.id}`
     };
   }
 }

--- a/src/services/recorders/redisRecorder.ts
+++ b/src/services/recorders/redisRecorder.ts
@@ -1,0 +1,46 @@
+import { SentMessageRecorder } from '../sentMessageRecorder.js';
+import { SentRecord } from '../../dto/messages.js';
+import { redis, isRedisConfigured, STREAM_SENT, ROUTING_MAXLEN } from '../../infra/redis.js';
+
+export class RedisRecorder implements SentMessageRecorder {
+  async recordSent(record: SentRecord): Promise<string> {
+    if (!redis) {
+      throw new Error('Redis not configured');
+    }
+    
+    const json = JSON.stringify(record);
+    const id = await redis.xadd(
+      STREAM_SENT, 'MAXLEN', '~', ROUTING_MAXLEN.toString(), '*', 'v', json
+    );
+    
+    const idxKey = `sent:index:${record.id}`;
+    await redis.hset(idxKey, {
+      ts: String(record.ts), 
+      to: record.to, 
+      chatId: record.chatId || '',
+      via: record.via, 
+      corr: record.correlationId || '',
+      waId: record.waMessageId || '', 
+      ddk: record.dedupeKey || ''
+    });
+    
+    return id;
+  }
+
+  async isHealthy(): Promise<boolean> {
+    if (!isRedisConfigured || !redis) {
+      return false;
+    }
+    
+    try {
+      await redis.ping();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  getBackendType(): string {
+    return 'redis';
+  }
+}

--- a/src/services/sentMessageRecorder.ts
+++ b/src/services/sentMessageRecorder.ts
@@ -27,10 +27,6 @@ export interface SentMessageRecorder {
  */
 export interface RecorderSettings {
   history_backend: 'redis' | 'base44';
-  base44?: {
-    url: string;
-    apiKey: string;
-  };
 }
 
 /**
@@ -45,10 +41,7 @@ export class SentMessageRecorderFactory {
       
       case 'base44':
         const { Base44Recorder } = await import('./recorders/base44Recorder.js');
-        if (!settings.base44?.url || !settings.base44?.apiKey) {
-          throw new Error('Base44 recorder requires URL and API key configuration');
-        }
-        return new Base44Recorder(settings.base44.url, settings.base44.apiKey);
+        return new Base44Recorder();
       
       default:
         return null;

--- a/src/services/sentMessageRecorder.ts
+++ b/src/services/sentMessageRecorder.ts
@@ -1,0 +1,57 @@
+import { SentRecord } from '../dto/messages.js';
+
+/**
+ * Interface for recording sent messages to different backends
+ */
+export interface SentMessageRecorder {
+  /**
+   * Record a sent message
+   * @param record The sent message record to store
+   * @returns Promise resolving to the record ID or identifier
+   */
+  recordSent(record: SentRecord): Promise<string>;
+
+  /**
+   * Check if the backend is available and healthy
+   */
+  isHealthy(): Promise<boolean>;
+
+  /**
+   * Get the backend name/type
+   */
+  getBackendType(): string;
+}
+
+/**
+ * Settings for different recorder backends
+ */
+export interface RecorderSettings {
+  history_backend: 'redis' | 'base44';
+  base44?: {
+    url: string;
+    apiKey: string;
+  };
+}
+
+/**
+ * Factory for creating message recorders based on settings
+ */
+export class SentMessageRecorderFactory {
+  static async create(settings: RecorderSettings): Promise<SentMessageRecorder | null> {
+    switch (settings.history_backend) {
+      case 'redis':
+        const { RedisRecorder } = await import('./recorders/redisRecorder.js');
+        return new RedisRecorder();
+      
+      case 'base44':
+        const { Base44Recorder } = await import('./recorders/base44Recorder.js');
+        if (!settings.base44?.url || !settings.base44?.apiKey) {
+          throw new Error('Base44 recorder requires URL and API key configuration');
+        }
+        return new Base44Recorder(settings.base44.url, settings.base44.apiKey);
+      
+      default:
+        return null;
+    }
+  }
+}

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -4,21 +4,8 @@ import { z } from 'zod';
 import pino from 'pino';
 import { RecorderSettings } from './sentMessageRecorder.js';
 
-const base44SettingsSchema = z.object({
-  url: z.string().url(),
-  apiKey: z.string().min(1)
-});
-
 const settingsSchema = z.object({
-  history_backend: z.enum(['redis', 'base44']).default('redis'),
-  base44: base44SettingsSchema.optional()
-}).refine((data) => {
-  if (data.history_backend === 'base44') {
-    return data.base44 && data.base44.url && data.base44.apiKey;
-  }
-  return true;
-}, {
-  message: "Base44 backend requires 'base44' configuration with 'url' and 'apiKey'"
+  history_backend: z.enum(['redis', 'base44']).default('redis')
 });
 
 export type AppSettings = z.infer<typeof settingsSchema>;
@@ -82,14 +69,8 @@ export class SettingsService {
   }
 
   public getRecorderSettings(): RecorderSettings {
-    const settings: RecorderSettings = {
+    return {
       history_backend: this.settings.history_backend
     };
-    
-    if (this.settings.base44) {
-      settings.base44 = this.settings.base44;
-    }
-    
-    return settings;
   }
 }

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import path from 'path';
+import { z } from 'zod';
+import pino from 'pino';
+import { RecorderSettings } from './sentMessageRecorder.js';
+
+const base44SettingsSchema = z.object({
+  url: z.string().url(),
+  apiKey: z.string().min(1)
+});
+
+const settingsSchema = z.object({
+  history_backend: z.enum(['redis', 'base44']).default('redis'),
+  base44: base44SettingsSchema.optional()
+}).refine((data) => {
+  if (data.history_backend === 'base44') {
+    return data.base44 && data.base44.url && data.base44.apiKey;
+  }
+  return true;
+}, {
+  message: "Base44 backend requires 'base44' configuration with 'url' and 'apiKey'"
+});
+
+export type AppSettings = z.infer<typeof settingsSchema>;
+
+export class SettingsService {
+  private readonly logger = pino({ level: process.env.LOG_LEVEL || 'info' });
+  private readonly settingsFile: string;
+  private settings: AppSettings;
+
+  constructor(dataDir = path.resolve(process.cwd(), 'data')) {
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+    this.settingsFile = path.join(dataDir, 'settings.json');
+    this.settings = this.loadSettings();
+  }
+
+  private loadSettings(): AppSettings {
+    try {
+      if (fs.existsSync(this.settingsFile)) {
+        const raw = fs.readFileSync(this.settingsFile, 'utf8');
+        const parsed = JSON.parse(raw);
+        return settingsSchema.parse(parsed);
+      }
+    } catch (err) {
+      this.logger.warn({ err }, 'Failed to load settings, using defaults');
+    }
+    
+    // Default settings
+    const defaultSettings: AppSettings = {
+      history_backend: 'redis'
+    };
+    
+    this.saveSettings(defaultSettings);
+    return defaultSettings;
+  }
+
+  private saveSettings(settings: AppSettings): void {
+    try {
+      fs.writeFileSync(this.settingsFile, JSON.stringify(settings, null, 2));
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to save settings');
+    }
+  }
+
+  public getSettings(): AppSettings {
+    return { ...this.settings };
+  }
+
+  public updateSettings(updates: Partial<AppSettings>): AppSettings {
+    const newSettings = { ...this.settings, ...updates };
+    
+    // Validate the new settings
+    const validated = settingsSchema.parse(newSettings);
+    
+    this.settings = validated;
+    this.saveSettings(this.settings);
+    
+    this.logger.info({ settings: this.settings }, 'Settings updated');
+    return { ...this.settings };
+  }
+
+  public getRecorderSettings(): RecorderSettings {
+    const settings: RecorderSettings = {
+      history_backend: this.settings.history_backend
+    };
+    
+    if (this.settings.base44) {
+      settings.base44 = this.settings.base44;
+    }
+    
+    return settings;
+  }
+}

--- a/src/types/ioredis.d.ts
+++ b/src/types/ioredis.d.ts
@@ -11,5 +11,7 @@ declare module 'ioredis' {
     ping(): Promise<string>
     set(key: string, value: string, mode: 'EX', seconds: number, condition: 'NX'): Promise<'OK' | null>
     del(key: string): Promise<number>
+    xadd(stream: string, maxlen: string, type: string, limit: string, id: string, field: string, value: string): Promise<string>
+    hset(key: string, data: Record<string, string>): Promise<number>
   }
 }

--- a/test/base44Recorder.test.js
+++ b/test/base44Recorder.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+test('Base44Recorder payload format validation', async () => {
+  const record = {
+    id: 'test-123',
+    ts: 1640995200000,
+    to: '972501234567',
+    chatId: '972501234567@s.whatsapp.net',
+    via: 'text',
+    bodyPreview: 'Test message content',
+    correlationId: 'scheduled-msg-456',
+    waMessageId: 'whatsapp-msg-789',
+    dedupeKey: 'dedupe-123'
+  }
+
+  // Test payload structure matches Base44 API spec
+  const expectedPayload = {
+    message_type: 'scheduled', // has correlationId and doesn't start with 'topic:'
+    number: '972501234567',
+    message: 'Test message content',
+    status: 'sent',
+    sent_at: '2022-01-01T00:00:00.000Z',
+    external_system: 'flyio-whatsapp-personal-api-v',
+    scheduled_message_id: 'scheduled-msg-456',
+    response_data: {
+      whatsapp_message_id: 'whatsapp-msg-789',
+      chat_id: '972501234567@s.whatsapp.net',
+      message_via: 'text',
+      dedupe_key: 'dedupe-123',
+      internal_record_id: 'test-123'
+    }
+  }
+
+  // Validate message_type logic
+  assert.equal(record.correlationId && !record.correlationId.startsWith('topic:'), true)
+  
+  // Validate external_system format
+  const flyReleaseVersion = process.env.FLY_RELEASE_VERSION || ''
+  const expectedExternalSystem = `flyio-whatsapp-personal-api-v${flyReleaseVersion}`
+  assert.equal(typeof expectedExternalSystem, 'string')
+  
+  // Validate timestamp format
+  const isoDate = new Date(record.ts).toISOString()
+  assert.equal(isoDate, '2022-01-01T00:00:00.000Z')
+})
+
+test('Base44Recorder message type detection', async () => {
+  const testCases = [
+    { correlationId: undefined, expected: 'instant' },
+    { correlationId: 'topic:broadcast-123', expected: 'instant' },
+    { correlationId: 'scheduled-msg-456', expected: 'scheduled' },
+    { correlationId: 'cron-job-789', expected: 'scheduled' }
+  ]
+
+  testCases.forEach(({ correlationId, expected }) => {
+    const messageType = correlationId?.startsWith('topic:') ? 'instant' : 
+                       correlationId ? 'scheduled' : 'instant'
+    assert.equal(messageType, expected, `Failed for correlationId: ${correlationId}`)
+  })
+})
+
+test('Base44Recorder configuration validation', async () => {
+  // Test environment variable requirements
+  const originalBase44Url = process.env.BASE44_URL
+  const originalBase44Key = process.env.BASE44_KEY
+  
+  // Clear env vars to test validation
+  delete process.env.BASE44_URL
+  delete process.env.BASE44_KEY
+  
+  const { Base44Recorder } = await import('../dist/services/recorders/base44Recorder.js')
+  const recorder = new Base44Recorder()
+  
+  // Should not be healthy without configuration
+  const healthy = await recorder.isHealthy()
+  assert.equal(healthy, false)
+  
+  // Restore env vars
+  if (originalBase44Url !== undefined) process.env.BASE44_URL = originalBase44Url
+  if (originalBase44Key !== undefined) process.env.BASE44_KEY = originalBase44Key
+})

--- a/test/sendIntegration.test.js
+++ b/test/sendIntegration.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import request from 'supertest'
+import { app } from '../dist/server.js'
+
+// Integration smoke test - verify /send endpoint doesn't break with sent recording
+test('POST /send endpoint with sent recording (smoke test)', async () => {
+  // This is a smoke test that verifies the endpoint doesn't crash
+  // In real usage, it would fail because WhatsApp is not connected, but
+  // we can verify that the sent recording logic doesn't break the flow
+  
+  const response = await request(app)
+    .post('/send')
+    .set('x-api-key', process.env.API_TOKENS?.split(',')[0] || 'test-key')
+    .send({
+      number: '1234567890',
+      message: 'Test message for sent recording'
+    })
+
+  // Should get 503 because WhatsApp is not connected in test environment
+  // But importantly, it shouldn't crash due to sent recording logic
+  assert.equal(response.status, 503)
+  assert.equal(response.body.success, false)
+  assert.equal(response.body.error, 'WhatsApp not connected')
+})
+
+test('POST /send endpoint handles missing recipient', async () => {
+  const response = await request(app)
+    .post('/send')
+    .set('x-api-key', process.env.API_TOKENS?.split(',')[0] || 'test-key')
+    .send({
+      message: 'Test message without recipient'
+    })
+
+  assert.equal(response.status, 400)
+  assert.equal(response.body.success, false)
+  assert(response.body.error.includes('Either number or jid must be provided'))
+})

--- a/test/sentRecorder.test.js
+++ b/test/sentRecorder.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// Simple unit test for the recordSent logic without Redis mocking complexity
+test('recordSent data structure validation', async () => {
+  const rec = {
+    id: 'test-123',
+    ts: 1640995200000,
+    to: '1234567890',
+    chatId: '1234567890@s.whatsapp.net',
+    via: 'text',
+    bodyPreview: 'Hello world',
+    correlationId: 'corr-123',
+    waMessageId: 'wa-msg-456',
+    dedupeKey: 'dedupe-789'
+  }
+
+  // Validate the JSON structure would be correct
+  const json = JSON.stringify(rec)
+  const parsed = JSON.parse(json)
+  
+  assert.equal(parsed.id, 'test-123')
+  assert.equal(parsed.ts, 1640995200000)
+  assert.equal(parsed.to, '1234567890')
+  assert.equal(parsed.via, 'text')
+  assert.equal(parsed.bodyPreview, 'Hello world')
+  assert.equal(parsed.correlationId, 'corr-123')
+  assert.equal(parsed.waMessageId, 'wa-msg-456')
+  assert.equal(parsed.dedupeKey, 'dedupe-789')
+})
+
+test('recordSent index key format', async () => {
+  const rec = {
+    id: 'test-456',
+    ts: Date.now(),
+    to: '9876543210',
+    via: 'text'
+  }
+
+  const expectedIdxKey = `sent:index:${rec.id}`
+  assert.equal(expectedIdxKey, 'sent:index:test-456')
+})
+
+test('recordSent hash data with missing optional fields', async () => {
+  const rec = {
+    id: 'test-minimal',
+    ts: 1640995300000,
+    to: '9876543210',
+    via: 'image'
+  }
+
+  // Validate the hash structure would be correct
+  const hashData = {
+    ts: String(rec.ts), 
+    to: rec.to, 
+    chatId: rec.chatId || '',
+    via: rec.via, 
+    corr: rec.correlationId || '',
+    waId: rec.waMessageId || '', 
+    ddk: rec.dedupeKey || ''
+  }
+
+  assert.equal(hashData.ts, '1640995300000')
+  assert.equal(hashData.to, '9876543210')
+  assert.equal(hashData.chatId, '')
+  assert.equal(hashData.via, 'image')
+  assert.equal(hashData.corr, '')
+  assert.equal(hashData.waId, '')
+  assert.equal(hashData.ddk, '')
+})

--- a/test/settingsEndpoints.test.js
+++ b/test/settingsEndpoints.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import request from 'supertest'
+import { app } from '../dist/server.js'
+
+const API_KEY = process.env.API_TOKENS?.split(',')[0] || 'test-key'
+
+test('GET /settings returns default settings', async () => {
+  const response = await request(app)
+    .get('/settings')
+    .set('x-api-key', API_KEY)
+
+  assert.equal(response.status, 200)
+  assert.equal(response.body.success, true)
+  assert.equal(response.body.settings.history_backend, 'redis')
+})
+
+test('PUT /settings updates backend configuration', async () => {
+  const response = await request(app)
+    .put('/settings')
+    .set('x-api-key', API_KEY)
+    .send({
+      history_backend: 'base44',
+      base44: {
+        url: 'https://test.example.com',
+        apiKey: 'test-api-key-123'
+      }
+    })
+
+  assert.equal(response.status, 200)
+  assert.equal(response.body.success, true)
+  assert.equal(response.body.settings.history_backend, 'base44')
+  assert.equal(response.body.settings.base44.url, 'https://test.example.com')
+})
+
+test('PUT /settings validates base44 configuration', async () => {
+  const response = await request(app)
+    .put('/settings')
+    .set('x-api-key', API_KEY)
+    .send({
+      history_backend: 'base44'
+      // Missing base44 config
+    })
+
+  assert.equal(response.status, 400)
+  assert.equal(response.body.success, false)
+  assert(response.body.error.includes('Base44 backend requires'))
+})
+
+test('GET /settings/recording-status returns backend status', async () => {
+  const response = await request(app)
+    .get('/settings/recording-status')
+    .set('x-api-key', API_KEY)
+
+  assert.equal(response.status, 200)
+  assert.equal(response.body.success, true)
+  assert(response.body.recording)
+  assert.equal(typeof response.body.recording.backend, 'string')
+  assert.equal(typeof response.body.recording.healthy, 'boolean')
+  assert.equal(typeof response.body.recording.available, 'boolean')
+})

--- a/test/settingsEndpoints.test.js
+++ b/test/settingsEndpoints.test.js
@@ -20,31 +20,25 @@ test('PUT /settings updates backend configuration', async () => {
     .put('/settings')
     .set('x-api-key', API_KEY)
     .send({
-      history_backend: 'base44',
-      base44: {
-        url: 'https://test.example.com',
-        apiKey: 'test-api-key-123'
-      }
+      history_backend: 'base44'
     })
 
   assert.equal(response.status, 200)
   assert.equal(response.body.success, true)
   assert.equal(response.body.settings.history_backend, 'base44')
-  assert.equal(response.body.settings.base44.url, 'https://test.example.com')
 })
 
-test('PUT /settings validates base44 configuration', async () => {
+test('PUT /settings accepts valid enum values', async () => {
   const response = await request(app)
     .put('/settings')
     .set('x-api-key', API_KEY)
     .send({
-      history_backend: 'base44'
-      // Missing base44 config
+      history_backend: 'invalid-backend'
     })
 
   assert.equal(response.status, 400)
   assert.equal(response.body.success, false)
-  assert(response.body.error.includes('Base44 backend requires'))
+  assert(response.body.error.includes('Invalid settings format'))
 })
 
 test('GET /settings/recording-status returns backend status', async () => {

--- a/test/settingsService.test.js
+++ b/test/settingsService.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'fs'
+import path from 'path'
+import { SettingsService } from '../dist/services/settingsService.js'
+
+test('SettingsService loads default settings', async () => {
+  const tempDir = path.join(process.cwd(), 'test-temp-settings')
+  
+  // Clean up any existing test files
+  if (fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true })
+  }
+  
+  const settings = new SettingsService(tempDir)
+  const loadedSettings = settings.getSettings()
+  
+  assert.equal(loadedSettings.history_backend, 'redis')
+  assert.equal(loadedSettings.base44, undefined)
+  
+  // Clean up
+  if (fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true })
+  }
+})
+
+test('SettingsService updates and persists settings', async () => {
+  const tempDir = path.join(process.cwd(), 'test-temp-settings-2')
+  
+  // Clean up any existing test files
+  if (fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true })
+  }
+  
+  const settings = new SettingsService(tempDir)
+  
+  const updated = settings.updateSettings({
+    history_backend: 'base44',
+    base44: {
+      url: 'https://test.example.com',
+      apiKey: 'test-api-key'
+    }
+  })
+  
+  assert.equal(updated.history_backend, 'base44')
+  assert.equal(updated.base44?.url, 'https://test.example.com')
+  assert.equal(updated.base44?.apiKey, 'test-api-key')
+  
+  // Verify persistence by creating a new instance
+  const settings2 = new SettingsService(tempDir)
+  const loadedSettings = settings2.getSettings()
+  
+  assert.equal(loadedSettings.history_backend, 'base44')
+  assert.equal(loadedSettings.base44?.url, 'https://test.example.com')
+  assert.equal(loadedSettings.base44?.apiKey, 'test-api-key')
+  
+  // Clean up
+  if (fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true })
+  }
+})
+
+test('SettingsService validates base44 configuration', async () => {
+  const tempDir = path.join(process.cwd(), 'test-temp-settings-3')
+  
+  // Clean up any existing test files
+  if (fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true })
+  }
+  
+  const settings = new SettingsService(tempDir)
+  
+  try {
+    settings.updateSettings({
+      history_backend: 'base44'
+      // Missing base44 config - should fail
+    })
+    assert.fail('Should have thrown validation error')
+  } catch (err) {
+    assert(err.message.includes('Base44 backend requires'))
+  }
+  
+  // Clean up
+  if (fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true })
+  }
+})

--- a/test/settingsService.test.js
+++ b/test/settingsService.test.js
@@ -35,24 +35,16 @@ test('SettingsService updates and persists settings', async () => {
   const settings = new SettingsService(tempDir)
   
   const updated = settings.updateSettings({
-    history_backend: 'base44',
-    base44: {
-      url: 'https://test.example.com',
-      apiKey: 'test-api-key'
-    }
+    history_backend: 'base44'
   })
   
   assert.equal(updated.history_backend, 'base44')
-  assert.equal(updated.base44?.url, 'https://test.example.com')
-  assert.equal(updated.base44?.apiKey, 'test-api-key')
   
   // Verify persistence by creating a new instance
   const settings2 = new SettingsService(tempDir)
   const loadedSettings = settings2.getSettings()
   
   assert.equal(loadedSettings.history_backend, 'base44')
-  assert.equal(loadedSettings.base44?.url, 'https://test.example.com')
-  assert.equal(loadedSettings.base44?.apiKey, 'test-api-key')
   
   // Clean up
   if (fs.existsSync(tempDir)) {
@@ -60,7 +52,7 @@ test('SettingsService updates and persists settings', async () => {
   }
 })
 
-test('SettingsService validates base44 configuration', async () => {
+test('SettingsService accepts base44 configuration without validation', async () => {
   const tempDir = path.join(process.cwd(), 'test-temp-settings-3')
   
   // Clean up any existing test files
@@ -70,15 +62,12 @@ test('SettingsService validates base44 configuration', async () => {
   
   const settings = new SettingsService(tempDir)
   
-  try {
-    settings.updateSettings({
-      history_backend: 'base44'
-      // Missing base44 config - should fail
-    })
-    assert.fail('Should have thrown validation error')
-  } catch (err) {
-    assert(err.message.includes('Base44 backend requires'))
-  }
+  // Should now accept base44 without additional config since secrets are handled via env vars
+  const updated = settings.updateSettings({
+    history_backend: 'base44'
+  })
+  
+  assert.equal(updated.history_backend, 'base44')
   
   // Clean up
   if (fs.existsSync(tempDir)) {


### PR DESCRIPTION
Add Sent-History recording to Redis Streams and a Hash index to track successfully sent messages.

This provides a persistent, queryable record of all outgoing messages, enabling future features like message status tracking and analytics, while ensuring no impact on existing message sending functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-876507e0-61a9-4154-b9c8-50f4fdb78cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-876507e0-61a9-4154-b9c8-50f4fdb78cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

