### PR TITLE
Update message text extraction logic

### DIFF
--- a/src/dto/messages.ts
+++ b/src/dto/messages.ts
@@ -1,4 +1,4 @@
-export type MessageType = 'text' | 'image' | 'audio' | 'video' | 'document' | 'sticker' | 'unknown'
+export type MessageType = 'text' | 'image' | 'audio' | 'video' | 'document' | 'sticker' | 'reaction' | 'unknown'
 
 export interface InboundMessage {
   id: string


### PR DESCRIPTION
Improve WhatsApp message text and type extraction to correctly populate the Redis payload for various message types, including ephemeral messages, media captions, and reactions.

The previous message conversion logic in `convertWAMessageToInbound` was incomplete, causing many messages (e.g., those wrapped in ephemeral containers, media with captions, interactive replies, and reactions) to be categorized as 'unknown' and their text content to be omitted from the `InboundMessage` object. This update introduces `unwrapMessage` and `extractTextAndType` to handle Baileys' nested message structures and extract text from all common carriers, ensuring the Redis stream accurately reflects the message content as per the PR specification.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c27a556-c372-4256-a25a-1c70f1a15f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c27a556-c372-4256-a25a-1c70f1a15f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

