### PR TITLE
Fetch past conversation messages for context

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ const openaiConfig = settings.openai ? {
   enabled: settings.openai.enabled ?? false,
   model: settings.openai.model ?? 'gpt-3.5-turbo'
 } : {}
-const openaiService = new OpenAIService(openaiConfig)
+const openaiService = new OpenAIService(openaiConfig, messageRecording)
 
 // Set up inbound message handler for recording and OpenAI processing
 whatsappClient.setMessageHandler(async (message) => {

--- a/src/services/sentMessageRecorder.ts
+++ b/src/services/sentMessageRecorder.ts
@@ -34,6 +34,15 @@ export interface InboundMessageRecorder {
   recordInbound(message: InboundMessage): Promise<string>;
 
   /**
+   * Retrieve past messages from the same conversation
+   * @param conversationKey The conversation identifier
+   * @param beforeTimestamp Optional timestamp to get messages before this time
+   * @param maxMessages Maximum number of messages to retrieve
+   * @returns Promise resolving to array of messages
+   */
+  getConversationHistory?(conversationKey: string, beforeTimestamp?: number, maxMessages?: number): Promise<InboundMessage[]>;
+
+  /**
    * Check if the backend is available and healthy
    */
   isHealthy(): Promise<boolean>;


### PR DESCRIPTION
Add conversation history as context to OpenAI prompts.

This improves OpenAI's contextual understanding by including past messages from the same conversation, configurable via `OPENAI_CONTEXT_MAX_DAYS` and `OPENAI_CONTEXT_MAX_MESSAGES` environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-0989dca2-6ca4-4f73-885a-3a46658e3f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0989dca2-6ca4-4f73-885a-3a46658e3f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

